### PR TITLE
Fix production build

### DIFF
--- a/build/index.html
+++ b/build/index.html
@@ -7,7 +7,5 @@
     <body>
         <div id="app"></div>
 
-        <!-- <script src="vendors.js"></script> -->
-        <script src="bundle.js"></script>
     </body>
 </html>

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Webpack, React, Babel, Mocha + JSDOM boilerplate",
   "main": "index.js",
   "scripts": {
-    "dev": "webpack-dev-server --dev-tool eval --progress --colors --hot --content-base build",
+    "start": "webpack-dev-server --dev-tool eval --progress --colors --hot --content-base build",
     "deploy": "NODE_ENV=production webpack -p --config webpack.production.config.js",
     "test": "mocha app/__tests__/* app/__tests__/**/*"
   },

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "babel-preset-react": "^6.3.13",
     "babel-register": "^6.4.3",
     "chai": "^3.4.1",
+    "html-webpack-plugin": "2.17.0",
     "jsdom": "^3.1.2",
     "mocha": "^2.3.4",
     "react": "^0.14.6",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,3 +1,4 @@
+var HtmlWebpackPlugin = require('html-webpack-plugin');
 var webpack = require('webpack');
 var path = require('path');
 var resolve = function (dir) {
@@ -15,7 +16,11 @@ module.exports = {
         filename: 'bundle.js'
     },
     plugins: [
-        new webpack.HotModuleReplacementPlugin()
+        new webpack.HotModuleReplacementPlugin(),
+        new HtmlWebpackPlugin({
+         append: true,
+         template: path.join(__dirname, 'build/index.html')
+     })
     ],
     module: {
         loaders: [

--- a/webpack.production.config.js
+++ b/webpack.production.config.js
@@ -1,3 +1,4 @@
+var webpack = require('webpack');
 var path = require('path');
 var resolve = function (dir) {
     return path.resolve(__dirname, dir);

--- a/webpack.production.config.js
+++ b/webpack.production.config.js
@@ -1,3 +1,4 @@
+var HtmlWebpackPlugin = require('html-webpack-plugin');
 var webpack = require('webpack');
 var path = require('path');
 var resolve = function (dir) {
@@ -24,6 +25,10 @@ module.exports = {
         }]
     },
     plugins: [
-        new webpack.optimize.CommonsChunkPlugin('vendors', 'vendors.js')
+        new webpack.optimize.CommonsChunkPlugin('vendors', 'vendors.js'),
+        new HtmlWebpackPlugin({
+         append: true,
+         template: path.join(__dirname, 'build/index.html')
+     })
     ]
 };


### PR DESCRIPTION
This PR fixes the production build.
- Webpack is now required correctly in the `webpack.production.config.js`
- A copy of the `index.html` file is created for production with references to the JavaScript files, using `html-webpack-plugin`
- Finally the is now started with `npm start`, as the README states.

Let me know if you want changes to way I have solved these problems
